### PR TITLE
Optimize cmake daemon

### DIFF
--- a/Source/cmAlgorithms.h
+++ b/Source/cmAlgorithms.h
@@ -52,13 +52,13 @@ template<typename T, size_t N>
 size_t cmArraySize(const T (&)[N]) { return N; }
 
 template<typename T, size_t N>
-bool cmHasLiteralPrefix(T str1, const char (&str2)[N])
+bool cmHasLiteralPrefix(const T& str1, const char (&str2)[N])
 {
   return cmHasLiteralPrefixImpl(str1, str2, N - 1);
 }
 
 template<typename T, size_t N>
-bool cmHasLiteralSuffix(T str1, const char (&str2)[N])
+bool cmHasLiteralSuffix(const T& str1, const char (&str2)[N])
 {
   return cmHasLiteralSuffixImpl(str1, str2, N - 1);
 }

--- a/Source/cmGeneratorTarget.cxx
+++ b/Source/cmGeneratorTarget.cxx
@@ -335,7 +335,7 @@ cmState::TargetType cmGeneratorTarget::GetType() const
 }
 
 //----------------------------------------------------------------------------
-std::string cmGeneratorTarget::GetName() const
+const std::string& cmGeneratorTarget::GetName() const
 {
   return this->Target->GetName();
 }

--- a/Source/cmGeneratorTarget.h
+++ b/Source/cmGeneratorTarget.h
@@ -55,7 +55,7 @@ public:
     GetLinkInformation(const std::string& config) const;
 
   cmState::TargetType GetType() const;
-  std::string GetName() const;
+  const std::string& GetName() const;
   std::string GetExportName() const;
 
   std::vector<std::string> GetPropertyKeys() const;

--- a/Source/cmGlobalGenerator.cxx
+++ b/Source/cmGlobalGenerator.cxx
@@ -2198,9 +2198,9 @@ cmGlobalGenerator::FindGeneratorTargetImpl(std::string const& name) const
 {
   for (unsigned int i = 0; i < this->LocalGenerators.size(); ++i)
     {
-    std::vector<cmGeneratorTarget*> tgts =
+    const std::vector<cmGeneratorTarget*>& tgts =
         this->LocalGenerators[i]->GetGeneratorTargets();
-    for (std::vector<cmGeneratorTarget*>::iterator it = tgts.begin();
+    for (std::vector<cmGeneratorTarget*>::const_iterator it = tgts.begin();
          it != tgts.end(); ++it)
       {
       if ((*it)->GetName() == name)
@@ -2217,9 +2217,9 @@ cmGlobalGenerator::FindImportedTargetImpl(std::string const& name) const
 {
   for (unsigned int i = 0; i < this->Makefiles.size(); ++i)
     {
-    std::vector<cmTarget*> tgts =
+    const std::vector<cmTarget*>& tgts =
         this->Makefiles[i]->GetOwnedImportedTargets();
-    for (std::vector<cmTarget*>::iterator it = tgts.begin();
+    for (std::vector<cmTarget*>::const_iterator it = tgts.begin();
          it != tgts.end(); ++it)
       {
       if ((*it)->GetName() == name && (*it)->IsImportedGloballyVisible())
@@ -2236,9 +2236,9 @@ cmGeneratorTarget* cmGlobalGenerator::FindImportedGeneratorTargetImpl(
 {
   for (unsigned int i = 0; i < this->LocalGenerators.size(); ++i)
     {
-    std::vector<cmGeneratorTarget*> tgts =
+    const std::vector<cmGeneratorTarget*>& tgts =
         this->LocalGenerators[i]->GetImportedGeneratorTargets();
-    for (std::vector<cmGeneratorTarget*>::iterator it = tgts.begin();
+    for (std::vector<cmGeneratorTarget*>::const_iterator it = tgts.begin();
          it != tgts.end(); ++it)
       {
       if ((*it)->IsImportedGloballyVisible() && (*it)->GetName() == name)

--- a/Source/cmMacroCommand.cxx
+++ b/Source/cmMacroCommand.cxx
@@ -146,16 +146,14 @@ bool cmMacroHelperCommand::InvokeInitialPass
         // replace formal arguments
         for (unsigned int j = 0; j < variables.size(); ++j)
           {
-          cmSystemTools::ReplaceString(arg.Value, variables[j].c_str(),
-                                       expandedArgs[j].c_str());
+          cmSystemTools::ReplaceString(arg.Value, variables[j],
+                                       expandedArgs[j]);
           }
         // replace argc
-        cmSystemTools::ReplaceString(arg.Value, "${ARGC}",argcDef.c_str());
+        cmSystemTools::ReplaceString(arg.Value, "${ARGC}", argcDef);
 
-        cmSystemTools::ReplaceString(arg.Value, "${ARGN}",
-                                     expandedArgn.c_str());
-        cmSystemTools::ReplaceString(arg.Value, "${ARGV}",
-                                     expandedArgv.c_str());
+        cmSystemTools::ReplaceString(arg.Value, "${ARGN}", expandedArgn);
+        cmSystemTools::ReplaceString(arg.Value, "${ARGV}", expandedArgv);
 
         // if the current argument of the current function has ${ARGV in it
         // then try replacing ARGV values
@@ -163,8 +161,8 @@ bool cmMacroHelperCommand::InvokeInitialPass
           {
           for (unsigned int t = 0; t < expandedArgs.size(); ++t)
             {
-            cmSystemTools::ReplaceString(arg.Value, argVs[t].c_str(),
-                                         expandedArgs[t].c_str());
+            cmSystemTools::ReplaceString(arg.Value, argVs[t],
+                                         expandedArgs[t]);
             }
           }
         }

--- a/Source/cmMakefile.cxx
+++ b/Source/cmMakefile.cxx
@@ -2832,10 +2832,9 @@ cmake::MessageType cmMakefile::ExpandVariablesInStringNew(
   const char* last = in;
   std::string result;
   result.reserve(source.size());
-  std::stack<t_lookup> openstack;
+  std::vector<t_lookup> openstack;
   bool error = false;
   bool done = false;
-  openstack.push(t_lookup());
   cmake::MessageType mtype = cmake::LOG;
 
   cmState* state = this->GetCMakeInstance()->GetState();
@@ -2846,10 +2845,10 @@ cmake::MessageType cmMakefile::ExpandVariablesInStringNew(
     switch(inc)
       {
       case '}':
-        if(openstack.size() > 1)
+        if(!openstack.empty())
           {
-          t_lookup var = openstack.top();
-          openstack.pop();
+          t_lookup var = openstack.back();
+          openstack.pop_back();
           result.append(last, in - last);
           std::string const& lookup = result.substr(var.loc);
           const char* value = NULL;
@@ -2970,7 +2969,7 @@ cmake::MessageType cmMakefile::ExpandVariablesInStringNew(
             last = start;
             in = start - 1;
             lookup.loc = result.size();
-            openstack.push(lookup);
+            openstack.push_back(lookup);
             }
           break;
           }
@@ -2997,7 +2996,7 @@ cmake::MessageType cmMakefile::ExpandVariablesInStringNew(
             result.append("\r");
             last = next + 1;
             }
-          else if(nextc == ';' && openstack.size() == 1)
+          else if(nextc == ';' && openstack.empty())
             {
             // Handled in ExpandListArgument; pass the backslash literally.
             }
@@ -3065,7 +3064,7 @@ cmake::MessageType cmMakefile::ExpandVariablesInStringNew(
         /* FALLTHROUGH */
       default:
         {
-        if(openstack.size() > 1 &&
+        if(!openstack.empty() &&
            !(isalnum(inc) || inc == '_' ||
              inc == '/' || inc == '.' ||
              inc == '+' || inc == '-'))
@@ -3074,7 +3073,7 @@ cmake::MessageType cmMakefile::ExpandVariablesInStringNew(
           errorstr += inc;
           result.append(last, in - last);
           errorstr += "\') in a variable name: "
-                      "'" + result.substr(openstack.top().loc) + "'";
+                      "'" + result.substr(openstack.back().loc) + "'";
           mtype = cmake::FATAL_ERROR;
           error = true;
           }
@@ -3085,7 +3084,7 @@ cmake::MessageType cmMakefile::ExpandVariablesInStringNew(
     } while(!error && !done && *++in);
 
   // Check for open variable references yet.
-  if(!error && openstack.size() != 1)
+  if(!error && !openstack.empty())
     {
     // There's an open variable reference waiting.  Policy CMP0010 flags
     // whether this is an error or not.  The new parser now enforces


### PR DESCRIPTION
I ran heaptrack on the daemon. It's not too bad when it comes to memory consumption, the biggest hotspot there are the hashes created from `cmDefinitions::makeClosure`. Note though that in my tests, the daemon only ever used ~40MB max, far away from the 900MB you saw for ParaView. I'll have a look at that eventually.

Is it OK to push these changes into your branch or should I put them directly up for review in cmake upstream? If so, how?
